### PR TITLE
Change "Source File:" to "SourceFile:" in mapper

### DIFF
--- a/mapper.py
+++ b/mapper.py
@@ -15,7 +15,7 @@ class ProguardMap(object):
     METHOD_MAPPING = re.compile(r'^(\d+):(\d+):.* (%s)\(.*\) -> (%s)$' % (JAVA_ID, JAVA_ID))
     OBFUSCATED_METHOD_REFERENCE = re.compile(r'((%s(\.%s)+)\.(%s))\((.*)\)' % (JAVA_ID, JAVA_ID, JAVA_ID))
     OBFUSCATED_CLASS_REFERENCE = re.compile(r'%s(\.%s)+' % (JAVA_ID, JAVA_ID))
-    SOURCE_LINE_INFO = re.compile(r'Source File:(\d+)')
+    SOURCE_LINE_INFO = re.compile(r'SourceFile:(\d+)')
 
     def __init__(self, map_file_name, verbose=False):
         """


### PR DESCRIPTION
Typically, a ProGuard configuration will use the following line to replace
the name of the source file in every class:

```
-renamesourcefileattribute SourceFile
```

Because of this, in order for method name deobfuscation to work as
expected, the mapper needs to look for the string "SourceFile:" instead of
"Source File:" when finding the line number after a method name.
